### PR TITLE
gltf_auto_export: Don't replace non-library collection instances by empties

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ you will get a warning **per entity**
 Thanks to all the contributors helping out with this project ! Big kudos to you, contributions are always appreciated ! :)
 
 - [GitGhillie](https://github.com/GitGhillie)
+- [Azorlogh](https://github.com/Azorlogh)
 
 ## License
 


### PR DESCRIPTION
Fixes: https://github.com/kaosat-dev/Blender_bevy_components_workflow/issues/34

Makes it so only collections that are actually from libraries will be replaced by empties