### PR TITLE
Fix export of main scene collections

### DIFF
--- a/tools/gltf_auto_export/gltf_auto_export.py
+++ b/tools/gltf_auto_export/gltf_auto_export.py
@@ -286,7 +286,6 @@ def generate_hollow_scene(scene, library_collections):
     root_collection = scene.collection 
     temp_scene = bpy.data.scenes.new(name="temp_scene")
     copy_root_collection = temp_scene.collection
-    scene_objects = [o for o in root_collection.objects]
 
     # we set our active scene to be this one : this is needed otherwise the stand-in empties get generated in the wrong scene
     bpy.context.window.scene = temp_scene
@@ -296,31 +295,43 @@ def generate_hollow_scene(scene, library_collections):
         print("FOUND COLLECTION")
         # once it's found, set the active layer collection to the one we found
         bpy.context.view_layer.active_layer_collection = found
-    
+
     #original_names = {}
     original_names = []
-    for object in scene_objects:
-        if object.instance_type == 'COLLECTION' and (object.instance_collection.name in library_collections):
-            collection_name = object.instance_collection.name
 
-            #original_names[object.name] = object.name# + "____bak"
-            #print("custom properties", object, object.keys(), object.items())
-            #for k, e in object.items():
-            #    print("custom properties ", k, e)
-            print("object location", object.location)
-            original_name = object.name
-            original_names.append(original_name)
+    # copies the contents of a collection into another one while replacing library instances with empties
+    def copy_hollowed_collection_into(source_collection, destination_collection):
+        for object in source_collection.objects:
+            if object.instance_type == 'COLLECTION' and (object.instance_collection.name in library_collections):
+                collection_name = object.instance_collection.name
 
-            object.name = original_name + "____bak"
-            empty_obj = make_empty3(original_name, object.location, object.rotation_euler, object.scale, copy_root_collection)
-            """we inject the collection/blueprint name, as a component called 'BlueprintName', but we only do this in the empty, not the original object"""
-            empty_obj['BlueprintName'] = '"'+collection_name+'"'
-            empty_obj['SpawnHere'] = ''
+                #original_names[object.name] = object.name# + "____bak"
+                #print("custom properties", object, object.keys(), object.items())
+                #for k, e in object.items():
+                #    print("custom properties ", k, e)
+                print("object location", object.location)
+                original_name = object.name
+                original_names.append(original_name)
 
-            for k, v in object.items():
-                empty_obj[k] = v
-        else:
-            copy_root_collection.objects.link(object)
+                object.name = original_name + "____bak"
+                empty_obj = make_empty3(original_name, object.location, object.rotation_euler, object.scale, destination_collection)
+                """we inject the collection/blueprint name, as a component called 'BlueprintName', but we only do this in the empty, not the original object"""
+                empty_obj['BlueprintName'] = '"'+collection_name+'"'
+                empty_obj['SpawnHere'] = ''
+
+                for k, v in object.items():
+                    empty_obj[k] = v
+            else:
+                destination_collection.objects.link(object)
+
+        # for every sub-collection of the source, copy its content into a new sub-collection of the destination
+        for collection in source_collection.children:
+            copy_collection = bpy.data.collections.new(collection.name + "____collection_export")
+            copy_hollowed_collection_into(collection, copy_collection)
+            destination_collection.children.link(copy_collection)
+
+    copy_hollowed_collection_into(root_collection, copy_root_collection)
+    
 
     # bpy.data.scenes.remove(temp_scene)
     # objs = bpy.data.objects
@@ -330,13 +341,17 @@ def generate_hollow_scene(scene, library_collections):
 # clear & remove "hollow scene"
 def clear_hollow_scene(temp_scene, original_scene, original_names):
     # reset original names
-    root_collection = original_scene.collection 
-    scene_objects = [o for o in root_collection.objects]
+    root_collection = original_scene.collection
 
-    for object in scene_objects:
-        if object.instance_type == 'COLLECTION':
-            if object.name.endswith("____bak"):
-                object.name = object.name.replace("____bak", "")
+    def restore_original_names(collection):
+        for object in collection.objects:
+            if object.instance_type == 'COLLECTION':
+                if object.name.endswith("____bak"):
+                    object.name = object.name.replace("____bak", "")
+        for child_collection in collection.children:
+            restore_original_names(child_collection)
+    
+    restore_original_names(root_collection)
 
     # remove empties (only needed when we go via ops ????)
     root_collection = temp_scene.collection 


### PR DESCRIPTION
Fixes: #36 

Recursively traverses the main scene collections to create the hollow scene, so that objects in sub-collections are properly exported