### PR TITLE
restrict main_menu system to only run in AppState::MenuRunning

### DIFF
--- a/examples/bevy_gltf_blueprints/animation/src/game/mod.rs
+++ b/examples/bevy_gltf_blueprints/animation/src/game/mod.rs
@@ -122,7 +122,7 @@ impl Plugin for GamePlugin {
             )
             .add_systems(OnEnter(AppState::MenuRunning), setup_main_menu)
             .add_systems(OnExit(AppState::MenuRunning), teardown_main_menu)
-            .add_systems(Update, (main_menu))
+            .add_systems(Update, main_menu.run_if(in_state(AppState::MenuRunning)))
             .add_systems(OnEnter(AppState::AppRunning), setup_game);
     }
 }

--- a/examples/bevy_gltf_blueprints/basic/src/game/mod.rs
+++ b/examples/bevy_gltf_blueprints/basic/src/game/mod.rs
@@ -109,7 +109,7 @@ impl Plugin for GamePlugin {
             )
             .add_systems(OnEnter(AppState::MenuRunning), setup_main_menu)
             .add_systems(OnExit(AppState::MenuRunning), teardown_main_menu)
-            .add_systems(Update, (main_menu))
+            .add_systems(Update, main_menu.run_if(in_state(AppState::MenuRunning)))
             .add_systems(OnEnter(AppState::AppRunning), setup_game);
     }
 }

--- a/examples/bevy_gltf_blueprints/basic_xpbd_physics/src/game/mod.rs
+++ b/examples/bevy_gltf_blueprints/basic_xpbd_physics/src/game/mod.rs
@@ -101,7 +101,7 @@ impl Plugin for GamePlugin {
             )
             .add_systems(OnEnter(AppState::MenuRunning), setup_main_menu)
             .add_systems(OnExit(AppState::MenuRunning), teardown_main_menu)
-            .add_systems(Update, (main_menu))
+            .add_systems(Update, main_menu.run_if(in_state(AppState::MenuRunning)))
             .add_systems(OnEnter(AppState::AppRunning), setup_game);
     }
 }

--- a/examples/bevy_gltf_blueprints/multiple_levels/src/game/mod.rs
+++ b/examples/bevy_gltf_blueprints/multiple_levels/src/game/mod.rs
@@ -115,7 +115,7 @@ impl Plugin for GamePlugin {
             )
             .add_systems(OnEnter(AppState::MenuRunning), setup_main_menu)
             .add_systems(OnExit(AppState::MenuRunning), teardown_main_menu)
-            .add_systems(Update, (main_menu))
+            .add_systems(Update, main_menu.run_if(in_state(AppState::MenuRunning)))
             .add_systems(OnEnter(AppState::AppRunning), setup_game);
     }
 }


### PR DESCRIPTION
This is desired because hitting Return once we transition to AppState::AppRunning will trigger keycode.just_pressed in main_menu and set state to AppState::AppLoading. The game then crashes when it tries to create another scene, camera, etc...