### PR TITLE
Added ability to load individual files instead of folder

### DIFF
--- a/crates/bevy_gltf_blueprints/src/lib.rs
+++ b/crates/bevy_gltf_blueprints/src/lib.rs
@@ -45,7 +45,7 @@ impl Default for BluePrintBundle {
 #[derive(Clone, Resource)]
 pub struct BluePrintsConfig {
     pub(crate) format: GltfFormat,
-    pub(crate) library_folder: PathBuf,
+    pub(crate) library: BlueprintsLibrary,
     pub(crate) aabbs: bool,
 
     pub(crate) aabb_cache: HashMap<String, Aabb>, // cache for aabbs
@@ -75,16 +75,24 @@ impl fmt::Display for GltfFormat {
 /// Plugin for gltf blueprints
 pub struct BlueprintsPlugin {
     pub format: GltfFormat,
-    /// The base folder where library/blueprints assets are loaded from, relative to the executable.
-    pub library_folder: PathBuf,
+    /// The base folder or files where library/blueprints assets are loaded from, relative to the executable.
+    pub library: BlueprintsLibrary,
     pub aabbs: bool,
+}
+
+/// Specifies whether to load a `Folder` or list of `Files`. Note that in WASM
+/// environments, using a `Folder` will result in an error.
+#[derive(Debug, Clone)]
+pub enum BlueprintsLibrary {
+    Folder(PathBuf),
+    Files(Vec<PathBuf>),
 }
 
 impl Default for BlueprintsPlugin {
     fn default() -> Self {
         Self {
             format: GltfFormat::GLB,
-            library_folder: PathBuf::from("models/library"),
+            library: BlueprintsLibrary::Folder(PathBuf::from("models/library")),
             aabbs: false,
         }
     }
@@ -102,7 +110,7 @@ impl Plugin for BlueprintsPlugin {
             .register_type::<Animations>()
             .insert_resource(BluePrintsConfig {
                 format: self.format.clone(),
-                library_folder: self.library_folder.clone(),
+                library: self.library.clone(),
                 aabbs: self.aabbs,
                 aabb_cache: HashMap::new(),
             })

--- a/crates/bevy_gltf_blueprints/src/spawn_from_blueprints.rs
+++ b/crates/bevy_gltf_blueprints/src/spawn_from_blueprints.rs
@@ -54,8 +54,18 @@ pub(crate) fn spawn_from_blueprints(
         debug!("need to spawn {:?}", blupeprint_name.0);
         let what = &blupeprint_name.0;
         let model_file_name = format!("{}.{}", &what, &blueprints_config.format);
-        let model_path =
-            Path::new(&blueprints_config.library_folder).join(Path::new(model_file_name.as_str()));
+        let model_path = {
+            match &blueprints_config.library {
+                crate::BlueprintsLibrary::Folder(folder) => {
+                    folder.join(Path::new(model_file_name.as_str()))
+                }
+                crate::BlueprintsLibrary::Files(files) => files
+                    .iter()
+                    .find(|x| x.file_name().unwrap().to_str().unwrap() == model_file_name)
+                    .cloned()
+                    .unwrap(),
+            }
+        };
 
         debug!("attempting to spawn {:?}", model_path);
         let model_handle: Handle<Gltf> = asset_server.load(model_path);

--- a/examples/bevy_gltf_blueprints/animation/src/core/mod.rs
+++ b/examples/bevy_gltf_blueprints/animation/src/core/mod.rs
@@ -21,7 +21,7 @@ impl Plugin for CorePlugin {
             CameraPlugin,
             PhysicsPlugin,
             BlueprintsPlugin {
-                library_folder: "models/library".into(),
+                library: BlueprintsLibrary::Folder("models/library".into()),
                 ..Default::default()
             },
         ));

--- a/examples/bevy_gltf_blueprints/basic/src/core/mod.rs
+++ b/examples/bevy_gltf_blueprints/basic/src/core/mod.rs
@@ -25,7 +25,7 @@ impl Plugin for CorePlugin {
             PhysicsPlugin,
             // SaveLoadPlugin,
             BlueprintsPlugin {
-                library_folder: "models/library".into(),
+                library: BlueprintsLibrary::Folder("models/library".into()),
                 format: GltfFormat::GLB,
                 aabbs: true,
                 ..Default::default()

--- a/examples/bevy_gltf_blueprints/basic_xpbd_physics/src/core/mod.rs
+++ b/examples/bevy_gltf_blueprints/basic_xpbd_physics/src/core/mod.rs
@@ -21,7 +21,7 @@ impl Plugin for CorePlugin {
             CameraPlugin,
             PhysicsPlugin,
             BlueprintsPlugin {
-                library_folder: "models/library".into(),
+                library: BlueprintsLibrary::Folder("models/library".into()),
                 ..Default::default()
             },
         ));

--- a/examples/bevy_gltf_blueprints/multiple_levels/src/core/mod.rs
+++ b/examples/bevy_gltf_blueprints/multiple_levels/src/core/mod.rs
@@ -25,7 +25,7 @@ impl Plugin for CorePlugin {
             PhysicsPlugin,
             // SaveLoadPlugin,
             BlueprintsPlugin {
-                library_folder: "models/library".into(),
+                library: BlueprintsLibrary::Folder("models/library".into()),
                 ..Default::default()
             },
         ));


### PR DESCRIPTION
Not sure if you like this solution or not, but I am using this workflow in my project, and I wanted it to be run on WASM. It looks like the only thing needed to make this crate compatible was allow the user to specify a list of file paths in the `BlueprintsPlugin` instead of always a folder, as loading from a folder is not possible currently in browser.

Note that the `library_folder` changed to `library`, and a new `BlueprintsLibrary` enum was added to support either option and still make sense.

E.g.

```rs
BlueprintsPlugin {
  library: BlueprintsLibrary::Folder("levels/library"),
  format: GltfFormat::GLB,
  ..Default::default()
}

BlueprintsPlugin {
  library: BlueprintsLibrary::Files(vec![
      "levels/library/goal.glb".into(),
      "levels/library/player.glb".into(),
      "levels/library/powerup_spawner.glb".into(),
  ]),
  format: GltfFormat::GLB,
  ..Default::default()
}
```

