### PR TITLE
fix(tools/gltf_auto_export): correctly scan for sub collections in main scenes

### DIFF
--- a/tools/gltf_auto_export/__init__.py
+++ b/tools/gltf_auto_export/__init__.py
@@ -57,7 +57,7 @@ This is a workaround needed because of the way the settings are stored , perhaps
 @persistent
 def deps_update_handler(scene, depsgraph):
     if scene.name != "temp_scene": # actually do we care about anything else than the main scene(s) ?
-        print("depsgraph_update_post", scene.name)
+        #print("depsgraph_update_post", scene.name)
         print("-------------")
         changed = scene.name or ""
 

--- a/tools/gltf_auto_export/helpers_collections.py
+++ b/tools/gltf_auto_export/helpers_collections.py
@@ -2,11 +2,10 @@ import bpy
 from .helpers import traverse_tree
 
 # returns the list of the collections in use for a given scene
-# FIXME: this should also look into sub collections
 def get_used_collections(scene): 
     root_collection = scene.collection 
 
-    scene_objects = [o for o in root_collection.objects]
+    scene_objects = [o for o in root_collection.all_objects]
     collection_names = set()
     used_collections = []
     for object in scene_objects:
@@ -117,7 +116,7 @@ def get_exportable_collections(main_scenes, library_scenes, addon_prefs):
     children_per_collection = {}
     flatten_collection_tree(root_node, children_per_collection)
     #print("ROOT NODE", children_per_collection) #
-
+    
     return (all_collection_names, children_per_collection)
 
 def get_collections_per_scene(collection_names, library_scenes): 

--- a/tools/gltf_auto_export/preferences.py
+++ b/tools/gltf_auto_export/preferences.py
@@ -128,9 +128,6 @@ class AutoExportGltfAddonPreferences(AddonPreferences):
             ('GLB', 'glTF Binary (.glb)',
                 'Exports a single file, with all data packed in binary form. '
                 'Most efficient and portable, but more difficult to edit later'),
-               ('GLTF_EMBEDDED', 'glTF Embedded (.gltf)',
-                'Exports a single file, with all data packed in JSON. '
-                'Less efficient than binary, but easier to edit later'),
                ('GLTF_SEPARATE', 'glTF Separate (.gltf + .bin + textures)',
                 'Exports multiple files, with separate JSON, binary and texture data. '
                 'Easiest to edit later')


### PR DESCRIPTION
 * scans for 'in-use' collections now correctly looks inside sub collections as well
 * removed obsolete .gltf output (keeping only .glb & .gltf+bin+textures
 * closes #92 
 * closes #93 
 