### PR TITLE
Fix invalid lints entry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,9 +29,6 @@ redundant_else = "warn"
 match_same_arms = "warn"
 semicolon_if_nothing_returned = "warn"
 
-[lints]
-workspace = true
-
 #### --------------------Dev/ debug-------------------------------
 # Enable high optimizations for dependencies (incl. Bevy), but not for our code:
 [profile.dev.package."*"]


### PR DESCRIPTION
Per the [Cargo book](https://doc.rust-lang.org/cargo/reference/workspaces.html#the-lints-table), this entry is only valid for the member crates, not the workspace manifest.