### PR TITLE
Remove nonexistent manifest key

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,9 +34,6 @@ semicolon_if_nothing_returned = "warn"
 [profile.dev.package."*"]
 opt-level = 3
 
-[profile.dev.package.bevy]
-features = ["dynamic"]
-
 #### --------------------Production/ release-------------------------------
 [profile.release]
 strip = "debuginfo"

--- a/crates/bevy_gltf_components/src/ronstring_to_reflect_component.rs
+++ b/crates/bevy_gltf_components/src/ronstring_to_reflect_component.rs
@@ -18,6 +18,10 @@ pub fn ronstring_to_reflect_component(
         let type_string = key.replace("component: ", "").trim().to_string();
         let capitalized_type_name = capitalize_first_letter(type_string.as_str());
 
+        if &capitalized_type_name == "Components_meta" {
+            continue;
+        }
+
         let mut parsed_value: String;
         match value.clone() {
             Value::String(str) => {

--- a/crates/bevy_gltf_components/src/ronstring_to_reflect_component.rs
+++ b/crates/bevy_gltf_components/src/ronstring_to_reflect_component.rs
@@ -19,6 +19,7 @@ pub fn ronstring_to_reflect_component(
         if &type_string == "components_meta" {
             continue;
         }
+        info!("{}", type_string);
         let capitalized_type_name = capitalize_first_letter(type_string.as_str());
 
         let mut parsed_value: String;

--- a/crates/bevy_gltf_components/src/ronstring_to_reflect_component.rs
+++ b/crates/bevy_gltf_components/src/ronstring_to_reflect_component.rs
@@ -19,7 +19,6 @@ pub fn ronstring_to_reflect_component(
         if &type_string == "components_meta" {
             continue;
         }
-        info!("{}", type_string);
         let capitalized_type_name = capitalize_first_letter(type_string.as_str());
 
         let mut parsed_value: String;

--- a/crates/bevy_gltf_components/src/ronstring_to_reflect_component.rs
+++ b/crates/bevy_gltf_components/src/ronstring_to_reflect_component.rs
@@ -16,9 +16,6 @@ pub fn ronstring_to_reflect_component(
     let mut components: Vec<(Box<dyn Reflect>, TypeRegistration)> = Vec::new();
     for (key, value) in lookup.into_iter() {
         let type_string = key.replace("component: ", "").trim().to_string();
-        if &type_string == "components_meta" {
-            continue;
-        }
         let capitalized_type_name = capitalize_first_letter(type_string.as_str());
 
         let mut parsed_value: String;

--- a/crates/bevy_gltf_components/src/ronstring_to_reflect_component.rs
+++ b/crates/bevy_gltf_components/src/ronstring_to_reflect_component.rs
@@ -16,11 +16,10 @@ pub fn ronstring_to_reflect_component(
     let mut components: Vec<(Box<dyn Reflect>, TypeRegistration)> = Vec::new();
     for (key, value) in lookup.into_iter() {
         let type_string = key.replace("component: ", "").trim().to_string();
-        let capitalized_type_name = capitalize_first_letter(type_string.as_str());
-
-        if &capitalized_type_name == "Components_meta" {
+        if &type_string == "components_meta" {
             continue;
         }
+        let capitalized_type_name = capitalize_first_letter(type_string.as_str());
 
         let mut parsed_value: String;
         match value.clone() {


### PR DESCRIPTION
Removed a setting in your Cargo.toml that currently does not do anything because the key is nonexistent.