### PR TITLE
Fix crash

### DIFF
--- a/crates/bevy_gltf_blueprints/src/lib.rs
+++ b/crates/bevy_gltf_blueprints/src/lib.rs
@@ -19,7 +19,11 @@ pub use copy_components::*;
 use core::fmt;
 use std::path::PathBuf;
 
-use bevy::{prelude::*, render::primitives::Aabb, utils::HashMap};
+use bevy::{
+    prelude::*,
+    render::{primitives::Aabb, view::VisibilitySystems},
+    utils::HashMap,
+};
 use bevy_gltf_components::{ComponentsFromGltfPlugin, GltfComponentsSet};
 
 #[derive(SystemSet, Debug, Hash, PartialEq, Eq, Clone)]
@@ -153,7 +157,8 @@ impl Plugin for BlueprintsPlugin {
             PostUpdate,
             (spawned_blueprint_post_process, apply_deferred)
                 .chain()
-                .in_set(GltfBlueprintsSet::AfterSpawn),
+                .in_set(GltfBlueprintsSet::AfterSpawn)
+                .before(VisibilitySystems::CheckVisibility),
         );
     }
 }

--- a/crates/bevy_gltf_blueprints/src/lib.rs
+++ b/crates/bevy_gltf_blueprints/src/lib.rs
@@ -150,7 +150,7 @@ impl Plugin for BlueprintsPlugin {
                 .in_set(GltfBlueprintsSet::Spawn),
         )
         .add_systems(
-            Update,
+            PostUpdate,
             (spawned_blueprint_post_process, apply_deferred)
                 .chain()
                 .in_set(GltfBlueprintsSet::AfterSpawn),


### PR DESCRIPTION
Fixes #156 
I tried to put it one schedule earlier (`SpawnScene` and `after(scene_spawner_system)`) and still got the "cannot clone component: component: {:?} is not registered" warning from `copy_components` sometimes, so it's in `PostUpdate` now.

The underlying issue seemed to be that `copy_components` makes assumptions about the state of the type registry but is actually in a race condition with it. I couldn't find the actual system that we implicitly depend on, otherwise I'd put it in a `.after()`, but this seems to work for now.